### PR TITLE
[modify]commitment.rb

### DIFF
--- a/app/models/commitment.rb
+++ b/app/models/commitment.rb
@@ -9,6 +9,7 @@ class Commitment < ApplicationRecord
   end
 
   def self.search_for(content)
-    Commitment.where(['room_name LIKE ?', "%#{content}%"])
+    #Commitmentを省略
+    Where(['room_name LIKE ?', "%#{content}%"])
   end
 end


### PR DESCRIPTION
searchメソッド内の「Commitment.where」を「Where」に省略しました。
同モデル内では省略可能のため。